### PR TITLE
fix: remove deprecated privateTours reference in About page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -31,9 +31,6 @@ export default function AboutPage() {
               <p className="text-slate-700 text-xl max-w-4xl mx-auto leading-relaxed">
                 {AboutPageText.description}
               </p>
-              <p className="text-slate-700 text-lg max-w-4xl mx-auto leading-relaxed mt-4">
-                {AboutPageText.privateTours}
-              </p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
- Remove reference to AboutPageText.privateTours that was removed from text config
- Information is now included in the description field
- Fixes production build error

🤖 Generated with [Claude Code](https://claude.ai/code)