### PR TITLE
fix: resolve BUG-001 - pricing inconsistencies across pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -150,7 +150,7 @@ export default function Page() {
                 onClick={() => setIsBookingModalOpen(true)}
                 className="inline-flex items-center px-8 py-4 bg-gradient-to-r from-green-500 to-emerald-500 text-white font-semibold rounded-2xl shadow-neon hover:shadow-lg transform hover:-translate-y-1 transition-all duration-300"
               >
-                ⚡ Quick Book - Solo $399
+                ⚡ Quick Book (From $250)
               </button>
             </div>
           </div>
@@ -388,7 +388,7 @@ export default function Page() {
               onClick={() => setIsBookingModalOpen(true)}
               className="inline-flex items-center px-8 py-3 bg-gradient-to-r from-green-500 to-emerald-500 text-white font-bold text-lg rounded-xl shadow-2xl hover:shadow-3d transform hover:-translate-y-1 transition-all duration-300"
             >
-              ⚡ Quick Book (Solo $399)
+              ⚡ Quick Book (From $250)
             </button>
           </div>
         </div>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -385,7 +385,7 @@ export default function PricingPage() {
                 onClick={() => setIsBookingModalOpen(true)}
                 className="inline-flex items-center px-8 py-3 bg-gradient-to-r from-green-500 to-emerald-500 text-white font-bold text-lg rounded-xl shadow-2xl hover:shadow-3d transform hover:-translate-y-1 transition-all duration-300"
               >
-                ✈️ Quick Book (Solo)
+                ✈️ Quick Book
               </button>
             </div>
           </div>


### PR DESCRIPTION
FIXED: Critical pricing display inconsistencies identified in QA report
- Homepage: Changed "Solo $399" to "From $250" for accurate starting price
- Pricing page: Removed misleading "Solo" from quick book button
- All pricing now correctly references $250 starting price point
- FAQ pricing remains accurate with full breakdown by tour length
- Stripe products file confirmed as single source of truth

IMPACT: Eliminates customer confusion and potential billing disputes
TESTING: Build completes successfully, all pricing displays consistent

Resolves: BUG-001 (P1 Critical) from QA Bug Report 🤖 Generated with [Claude Code](https://claude.ai/code)